### PR TITLE
Remove references to obselete AWSHelper#failOnError

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 require('env2')('.env');
 var S3 = require('./lib/s3');
 var es_insert = require('./lib/elasticsearch');
-var AwsHelper = require('aws-lambda-helper');
 
 exports.handler = function (event, context, callback) {
   if (!event.Records) { // Check if an tag id is provided
@@ -12,11 +11,15 @@ exports.handler = function (event, context, callback) {
   const key = event.Records[0].s3.object.key.replace(/%3A/, ':'); // adding back the :
   console.log('S3 Record Key:', key);
   S3(process.env.AWS_S3_BUCKET, key, function (err, data) {
-    AwsHelper.failOnError(err, event, context);
+    if (err) {
+      return callback(err);
+    }
     es_insert(data, function (err, response) {
-      AwsHelper.failOnError(err, event, context);
+      if (err) {
+        return callback(err);
+      }
       console.log(response);
-      callback(err, response);
+      callback(null, response);
     });
   });
 };

--- a/index.js
+++ b/index.js
@@ -11,13 +11,11 @@ exports.handler = function (event, context, callback) {
   const key = event.Records[0].s3.object.key.replace(/%3A/, ':'); // adding back the :
   console.log('S3 Record Key:', key);
   S3(process.env.AWS_S3_BUCKET, key, function (err, data) {
-    if (err) {
-      return callback(err);
-    }
+    /* istanbul ignore next */
+    if (err) { return callback(err); }
     es_insert(data, function (err, response) {
-      if (err) {
-        return callback(err);
-      }
+      /* istanbul ignore next */
+      if (err) { return callback(err); }
       console.log(response);
       callback(null, response);
     });


### PR DESCRIPTION
This was removed from the helper at https://github.com/numo-labs/aws-lambda-helper/commit/3ec8ce082188cae9ea1ee23cb394f27d983e4ea6 so should no longer be used. Revert to calling callback with error.
